### PR TITLE
Remove log statement from consumer

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -172,7 +171,6 @@ var deaggregate = func(record *kinesis.Record) []*kinesis.Record {
 	src := record.Data[len(magicNumber) : len(record.Data)-md5.Size]
 	dest := new(aggregated.AggregatedRecord)
 	err := proto.Unmarshal(src, dest)
-	log.Println(err)
 	if err != nil {
 		return []*kinesis.Record{}
 	}


### PR DESCRIPTION
This log statement would cause kitkat to output log lines like ```2019/03/12 14:05:06 <nil>``` to stderr

Fixes #2