### PR TITLE
consume zlib compressed data records

### DIFF
--- a/command/consume.go
+++ b/command/consume.go
@@ -26,6 +26,7 @@ func init() {
 	cmd.Flags().Int64VarP(&c.Limit, "limit", "l", 500, "Limit records length of each GetRecords request")
 	cmd.Flags().Int64VarP(&c.Interval, "interval", "i", 100, "Interval in milliseconds between each GetRecords request")
 	cmd.Flags().StringVarP(&c.Since, "since", "t", "", "Show records since timestamp (e.g. 2016-04-20T12:00:00+09:00) when iterator type is AT_TIMESTAMP")
+	cmd.Flags().StringVarP(&c.Compress, "compress", "c", "none", "Compression method used in data records")
 }
 
 func consume(c *consumer.Consumer) runFunc {

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -283,7 +283,7 @@ func TestPrintRecords(t *testing.T) {
 		}()
 		isAggregated = test.mockIsAggregated
 		deaggregate = test.mockDeaggregate
-		printOneRecord = func(out io.Writer, stream string, shard *kinesis.Shard, record *kinesis.Record, verbose bool) {
+		printOneRecord = func(out io.Writer, stream string, shard *kinesis.Shard, record *kinesis.Record, compress string, verbose bool) {
 			fmt.Fprintln(out, string(record.Data))
 		}
 		_, err := c.printRecords(&fakeIterator, "fake-stream", new(kinesis.Shard))
@@ -388,6 +388,7 @@ func TestPrintOneRecord(t *testing.T) {
 		shard    *kinesis.Shard
 		record   *kinesis.Record
 		expected string
+		compress string
 	}{
 		{
 			name:    "non verbose mode",
@@ -427,7 +428,7 @@ func TestPrintOneRecord(t *testing.T) {
 
 	for _, test := range cases {
 		var buf bytes.Buffer
-		printOneRecord(&buf, test.stream, test.shard, test.record, test.verbose)
+		printOneRecord(&buf, test.stream, test.shard, test.record, test.compress, test.verbose)
 		actual := buf.String()
 		assert.Equal(t, test.expected, actual, "test [%s] failed", test.name)
 	}


### PR DESCRIPTION
add a new option -c to specify the compression method, so the consumer can read compressed data record